### PR TITLE
feat add custom icons params

### DIFF
--- a/denops/@ddu-filters/converter_devicon.ts
+++ b/denops/@ddu-filters/converter_devicon.ts
@@ -7,7 +7,6 @@ import { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import {
   getCustomIconData,
   getIconData,
-  getSpecificFileIconData,
   IconData,
 } from "../ddu-devicon/main.ts";
 
@@ -18,7 +17,7 @@ type Params = {
   defaultIcon: string;
   defaultIconHlgroup: string;
   specificFileIcons: Record<string, IconData>;
-  customIcons: Record<string, IconData>;
+  extentionIcons: Record<string, IconData>;
 };
 
 const ENCODER = new TextEncoder();
@@ -59,11 +58,12 @@ export class Filter extends BaseFilter<Params> {
         is.ObjectOf({ action: is.ObjectOf({ isDirectory: is.Boolean }) })(item)
           ? item.action.isDirectory
           : undefined;
-      const customIcon = getSpecificFileIconData(
+      const customIcon = getCustomIconData(
         path,
         filterParams.specificFileIcons,
+        filterParams.extentionIcons,
         isDirectory,
-      ) ?? getCustomIconData(path, filterParams.customIcons, isDirectory);
+      );
       const iconData = customIcon ?? getIconData(path, isDirectory);
       const icon = iconData.icon ?? filterParams.defaultIcon;
       const hl_group = iconData.hl_group ?? filterParams.defaultIconHlgroup;
@@ -98,7 +98,7 @@ export class Filter extends BaseFilter<Params> {
       defaultIcon: "",
       defaultIconHlgroup: "",
       specificFileIcons: {},
-      customIcons: {},
+      extentionIcons: {},
     };
   }
 }

--- a/denops/@ddu-filters/converter_devicon.ts
+++ b/denops/@ddu-filters/converter_devicon.ts
@@ -2,7 +2,7 @@ import {
   BaseFilter,
   DduItem,
 } from "https://deno.land/x/ddu_vim@v3.2.6/types.ts";
-import { basename } from "https://deno.land/std@0.192.0/path/mod.ts";
+import { basename } from "https://deno.land/std@0.200.0/path/mod.ts";
 import { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import {
   getCustomIconData,

--- a/denops/@ddu-filters/converter_devicon.ts
+++ b/denops/@ddu-filters/converter_devicon.ts
@@ -4,7 +4,12 @@ import {
 } from "https://deno.land/x/ddu_vim@v3.2.6/types.ts";
 import { basename } from "https://deno.land/std@0.192.0/path/mod.ts";
 import { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
-import { getIconData } from "../ddu-devicon/main.ts";
+import {
+  getCustomIconData,
+  getIconData,
+  getSpecificFileIconData,
+  IconData,
+} from "../ddu-devicon/main.ts";
 
 const HIGHLIGHT_NAME = "ddu_devicon" as const satisfies string;
 
@@ -12,6 +17,8 @@ type Params = {
   padding: number;
   defaultIcon: string;
   defaultIconHlgroup: string;
+  specificFileIcons: Record<string, IconData>;
+  customIcons: Record<string, IconData>;
 };
 
 const ENCODER = new TextEncoder();
@@ -52,7 +59,12 @@ export class Filter extends BaseFilter<Params> {
         is.ObjectOf({ action: is.ObjectOf({ isDirectory: is.Boolean }) })(item)
           ? item.action.isDirectory
           : undefined;
-      const iconData = getIconData(path, isDirectory);
+      const customIcon = getSpecificFileIconData(
+        path,
+        filterParams.specificFileIcons,
+        isDirectory,
+      ) ?? getCustomIconData(path, filterParams.customIcons, isDirectory);
+      const iconData = customIcon ?? getIconData(path, isDirectory);
       const icon = iconData.icon ?? filterParams.defaultIcon;
       const hl_group = iconData.hl_group ?? filterParams.defaultIconHlgroup;
 
@@ -85,6 +97,8 @@ export class Filter extends BaseFilter<Params> {
       padding: 0,
       defaultIcon: "",
       defaultIconHlgroup: "",
+      specificFileIcons: {},
+      customIcons: {},
     };
   }
 }

--- a/denops/ddu-devicon/main.ts
+++ b/denops/ddu-devicon/main.ts
@@ -51,7 +51,7 @@ export function getCustomIconData(
       hl_group: customIcon.hl_group ?? (def && getHighlightGroup(def)),
     };
   }
-  const ext = extname(filename).slice(1, extname(filename).length);
+  const ext = extname(filename).slice(1);
   customIcon = extentionIcon[ext];
   if (customIcon) {
     return {

--- a/denops/ddu-devicon/main.ts
+++ b/denops/ddu-devicon/main.ts
@@ -1,6 +1,6 @@
 import { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import { batch } from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
-import { basename, extname } from "https://deno.land/std@0.200.0/path/mod.ts";
+import { extname } from "https://deno.land/std@0.200.0/path/mod.ts";
 import {
   DeviconDef,
   getDeviconDef,
@@ -34,37 +34,31 @@ export function getIconData(
   };
 }
 
-export function getSpecificFileIconData(
-  path: string,
-  specificFileIcons: Record<string, IconData>,
-  isFolder?: boolean,
-): IconData | undefined {
-  if (isFolder) {
-    return undefined;
-  }
-  const filename = basename(path);
-  return specificFileIcons[filename] ?? undefined;
-}
-
 export function getCustomIconData(
-  path: string,
-  customIconData: Record<string, IconData>,
+  filename: string,
+  specificFileIcon: Record<string, IconData>,
+  extentionIcon: Record<string, IconData>,
   isFolder?: boolean,
 ): IconData | undefined {
   if (isFolder) {
     return undefined;
   }
-  const def = getDeviconDef(path, isFolder);
-  const ext = (extname(path) === "")
-    ? basename(path)
-    : extname(path).slice(1, extname(path).length);
-  if (!customIconData[ext]) {
-    return undefined;
+  const def = getDeviconDef(filename, isFolder);
+  let customIcon = specificFileIcon[filename];
+  if (customIcon) {
+    return {
+      icon: customIcon.icon ?? (def?.icon ?? ""),
+      hl_group: customIcon.hl_group ?? (def && getHighlightGroup(def)),
+    };
   }
-  return {
-    icon: customIconData[ext].icon ?? (def?.icon ?? ""),
-    hl_group: customIconData[ext].hl_group ?? (def && getHighlightGroup(def)),
-  };
+  const ext = extname(filename).slice(1, extname(filename).length);
+  customIcon = extentionIcon[ext];
+  if (customIcon) {
+    return {
+      icon: customIcon.icon ?? (def?.icon ?? ""),
+      hl_group: customIcon.hl_group ?? (def && getHighlightGroup(def)),
+    };
+  }
 }
 
 export function main(denops: Denops) {

--- a/denops/ddu-devicon/main.ts
+++ b/denops/ddu-devicon/main.ts
@@ -17,7 +17,7 @@ async function setupHighlight(denops: Denops, def: DeviconDef) {
   await denops.cmd(`hi default ${hl_group} guifg=${def.color}`);
 }
 
-type IconData = {
+export type IconData = {
   icon?: string;
   hl_group?: string;
 };
@@ -31,6 +31,33 @@ export function getIconData(
     icon: def?.icon,
     hl_group: def && getHighlightGroup(def),
   };
+}
+
+export function getSpecificFileIconData(
+  path: string,
+  specificFileIcons: Record<string, IconData>,
+  isFolder?: boolean,
+): IconData | undefined {
+  if (isFolder) return undefined
+  const filename = path.match(/[^\/]+$/)
+  if (filename != null) {
+    return specificFileIcons[filename[0]] ?? undefined
+  }
+}
+
+export function getCustomIconData(
+  path: string,
+  customIconData: Record<string, IconData>,
+  isFolder?: boolean,
+): IconData | undefined {
+  if (isFolder) return undefined
+  const def = getDeviconDef(path, isFolder);
+  const ext = path.replace(/(.*)\./, "");
+  if (!customIconData[ext]) return undefined
+  return {
+    icon: customIconData[ext].icon ?? (def?.icon ?? ''),
+    hl_group: customIconData[ext].hl_group ?? (def && getHighlightGroup(def))
+  }
 }
 
 export function main(denops: Denops) {

--- a/denops/ddu-devicon/main.ts
+++ b/denops/ddu-devicon/main.ts
@@ -1,5 +1,6 @@
 import { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import { batch } from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
+import { basename, extname } from "https://deno.land/std@0.200.0/path/mod.ts";
 import {
   DeviconDef,
   getDeviconDef,
@@ -38,11 +39,11 @@ export function getSpecificFileIconData(
   specificFileIcons: Record<string, IconData>,
   isFolder?: boolean,
 ): IconData | undefined {
-  if (isFolder) return undefined
-  const filename = path.match(/[^\/]+$/)
-  if (filename != null) {
-    return specificFileIcons[filename[0]] ?? undefined
+  if (isFolder) {
+    return undefined;
   }
+  const filename = basename(path);
+  return specificFileIcons[filename] ?? undefined;
 }
 
 export function getCustomIconData(
@@ -50,14 +51,20 @@ export function getCustomIconData(
   customIconData: Record<string, IconData>,
   isFolder?: boolean,
 ): IconData | undefined {
-  if (isFolder) return undefined
-  const def = getDeviconDef(path, isFolder);
-  const ext = path.replace(/(.*)\./, "");
-  if (!customIconData[ext]) return undefined
-  return {
-    icon: customIconData[ext].icon ?? (def?.icon ?? ''),
-    hl_group: customIconData[ext].hl_group ?? (def && getHighlightGroup(def))
+  if (isFolder) {
+    return undefined;
   }
+  const def = getDeviconDef(path, isFolder);
+  const ext = (extname(path) === "")
+    ? basename(path)
+    : extname(path).slice(1, extname(path).length);
+  if (!customIconData[ext]) {
+    return undefined;
+  }
+  return {
+    icon: customIconData[ext].icon ?? (def?.icon ?? ""),
+    hl_group: customIconData[ext].hl_group ?? (def && getHighlightGroup(def)),
+  };
 }
 
 export function main(denops: Denops) {

--- a/doc/ddu-filter-converter_devicon.txt
+++ b/doc/ddu-filter-converter_devicon.txt
@@ -65,26 +65,26 @@ defaultIconHlgroup	(string)
 	Default: ""
 
 			 *ddu-filter-converter_devicon-param-specificFileIcons*
-specificFileIcons	(dictionary)
+specificFileIcons	(|Dictionary|)
 	Sets the icon applied to a file with a specific name. This param
 	should hold icon data keyed by file name. Icon data has icon
 	character and hl_group.
 
-	- icon data	(dictionary)
-	  Dictionary data with icon name as key.
+	- icon data	(|Dictionary|)
+	  |Dictionary| data with specific file name as key.
 	  It holds the following two data.
 
-	  - icon		(string)
+	  - icon		(string)	optional
 	    Set the icon you want to use.
-	    Default: ""
+	    Default: v:null
 
-	  - hl_group		(string)
+	  - hl_group		(string)	optional
 	    Set the highlight group you want to use.
 	    Setting this parameter will color the icon.
-	    Default: ""
+	    Default: v:null
 
-	NOTE: specificFileIcons do not have hl_group set by default.
-	If you want the icon to have a color you have to set it yourself.
+	NOTE: If the specific filename exists in the built-in, the built-in value
+	will automatically be used for items not set by the user.
 
 	Example:
 	  - Specific filename is devDockerfile.
@@ -112,18 +112,22 @@ specificFileIcons	(dictionary)
 <
 	Default: {}
 
-			       *ddu-filter-converter_devicon-param-customIcons*
-customIcons	(dictionary)
+			    *ddu-filter-converter_devicon-param-extentionIcons*
+extentionIcons	(|Dictionary|)
 	Manually specify an icon for each extension. This param	should hold
-	icon data keyed by file name. Icon data has icon character and
+	icon data keyed by extention name. Icon data has icon character and
 	hl_group.
-	See |ddu-filter-converter_devicon-param-specificFileIcons| for types.
 
-	NOTE: You don't have to set hl_group if you use the built-in icon
-	color.
+	- icon data	(|Dictionary|)
+	  |Dictionary| data with extension name as key.
+	  See the |ddu-filter-converter_devicon-param-specificFileIcons| for
+	  the data this dictionary holds.
+
+	NOTE: If there is a conflict with the setting of specificFileIcons,
+	the value of specificFileIcons takes precedence.
 
 	Example:
-	  - The target extension name is txt and Dockerfile.
+	  - The target extension name is txt and svg.
 	  - Icon color is build-in.
 >
 	call ddu#custom#patch_global(#{
@@ -133,12 +137,12 @@ customIcons	(dictionary)
 	    \       converters: [ #{
 	    \         name: 'converter_devicon',
 	    \         params: #{
-	    \           customIcons: #{
+	    \           extentionIcons: #{
 	    \             txt: #{
 	    \               icon: '',
 	    \             },
-	    \             Dockerfile: #{
-	    \               icon: '',
+	    \             svg: #{
+	    \               icon: '',
 	    \             },
 	    \           },
 	    \         },

--- a/doc/ddu-filter-converter_devicon.txt
+++ b/doc/ddu-filter-converter_devicon.txt
@@ -40,33 +40,6 @@ EXAMPLES				*ddu-filter-converter_devicon-examples*
 	    \     },
 	    \   }
 	    \ })
-
-	" customIcons setting examples
-	call ddu#custom#patch_global(#{
-	    \   sourceOptions: #{
-	    \     _: #{
-	    \       matchers: [ 'matcher_substring' ],
-	    \       converters: [ #{
-	    \         name: 'converter_devicon',
-	    \         params: #{
-	    \           specificFileIcons: #{
-	    \             devDockerfile: #{
-	    \               icon: '',
-	    \             },
-	    \           },
-	    \           customIcons: #{
-	    \             txt: #{
-	    \               icon: '',
-	    \             },
-	    \             Dockerfile: #{
-	    \               icon: '',
-	    \             },
-	    \           },
-	    \         },
-	    \       } ],
-	    \     },
-	    \   }
-	    \ })
 <
 
 ==============================================================================
@@ -93,14 +66,87 @@ defaultIconHlgroup	(string)
 
 			 *ddu-filter-converter_devicon-param-specificFileIcons*
 specificFileIcons	(dictionary)
-	Sets the icon applied to a file with a specific name.
+	Sets the icon applied to a file with a specific name. This param
+	should hold icon data keyed by file name. Icon data has icon
+	character and hl_group.
 
+	- icon data	(dictionary)
+	  Dictionary data with icon name as key.
+	  It holds the following two data.
+
+	  - icon		(string)
+	    Set the icon you want to use.
+	    Default: ""
+
+	  - hl_group		(string)
+	    Set the highlight group you want to use.
+	    Setting this parameter will color the icon.
+	    Default: ""
+
+	NOTE: specificFileIcons do not have hl_group set by default.
+	If you want the icon to have a color you have to set it yourself.
+
+	Example:
+	  - Specific filename is devDockerfile.
+	  - hl_group is DduDevIconRed.
+>
+	highlight DduDevIconRed guifg=red
+	call ddu#custom#patch_global(#{
+	    \   sourceOptions: #{
+	    \     _: #{
+	    \       matchers: [ 'matcher_substring' ],
+	    \       converters: [ #{
+	    \         name: 'converter_devicon',
+	    \         params: #{
+	    \           specificFileIcons: #{
+	    \             devDockerfile: #{
+	    \               icon: '',
+	    \               hl_group: 'DduDevIconRed',
+	    \             },
+	    \           },
+	    \         },
+	    \       } ],
+	    \     },
+	    \   }
+	    \ })
+<
 	Default: {}
 
 			       *ddu-filter-converter_devicon-param-customIcons*
 customIcons	(dictionary)
-	Manually specify an icon for each extension.
+	Manually specify an icon for each extension. This param	should hold
+	icon data keyed by file name. Icon data has icon character and
+	hl_group.
+	See |ddu-filter-converter_devicon-param-specificFileIcons| for types.
 
+	NOTE: You don't have to set hl_group if you use the built-in icon
+	color.
+
+	Example:
+	  - The target extension name is txt and Dockerfile.
+	  - Icon color is build-in.
+>
+	call ddu#custom#patch_global(#{
+	    \   sourceOptions: #{
+	    \     _: #{
+	    \       matchers: [ 'matcher_substring' ],
+	    \       converters: [ #{
+	    \         name: 'converter_devicon',
+	    \         params: #{
+	    \           customIcons: #{
+	    \             txt: #{
+	    \               icon: '',
+	    \             },
+	    \             Dockerfile: #{
+	    \               icon: '',
+	    \             },
+	    \           },
+	    \         },
+	    \       } ],
+	    \     },
+	    \   }
+	    \ })
+<
 	Default: {}
 
 

--- a/doc/ddu-filter-converter_devicon.txt
+++ b/doc/ddu-filter-converter_devicon.txt
@@ -40,6 +40,33 @@ EXAMPLES				*ddu-filter-converter_devicon-examples*
 	    \     },
 	    \   }
 	    \ })
+
+	" customIcons setting examples
+	call ddu#custom#patch_global(#{
+	    \   sourceOptions: #{
+	    \     _: #{
+	    \       matchers: [ 'matcher_substring' ],
+	    \       converters: [ #{
+	    \         name: 'converter_devicon',
+	    \         params: #{
+	    \           specificFileIcons: #{
+	    \             devDockerfile: #{
+	    \               icon: '',
+	    \             },
+	    \           },
+	    \           customIcons: #{
+	    \             txt: #{
+	    \               icon: '',
+	    \             },
+	    \             Dockerfile: #{
+	    \               icon: '',
+	    \             },
+	    \           },
+	    \         },
+	    \       } ],
+	    \     },
+	    \   }
+	    \ })
 <
 
 ==============================================================================
@@ -63,6 +90,18 @@ defaultIconHlgroup	(string)
 	name.
 
 	Default: ""
+
+			 *ddu-filter-converter_devicon-param-specificFileIcons*
+specificFileIcons	(dictionary)
+	Sets the icon applied to a file with a specific name.
+
+	Default: {}
+
+			       *ddu-filter-converter_devicon-param-customIcons*
+customIcons	(dictionary)
+	Manually specify an icon for each extension.
+
+	Default: {}
 
 
 ==============================================================================


### PR DESCRIPTION
Thank you nice filter!
I like this filter because it works faster than using columns.

# PR Summary
The user will be able to set:
- Assign icons to files with specific names
- Change icon by specifying extension

## Description
I'm using tmux and depending on the icon the ambiwidth setting doesn't work.
In such a case, it is convenient to be able to specify an icon.
Also, in some cases you may want to assign an icon to a special file name.

### My setting (clip)
```vim
        \  filterParams: #{
        \    converter_devicon: #{
        \      specificFileIcons: #{
        \        devDockerfile: #{
        \          icon: '',
        \        },
        \      },
        \      customIcons: #{
        \        txt: #{
        \          icon: '',
        \        },
        \        Dockerfile: #{
        \          icon: '',
        \        },
        \      },
        \    },
        \  },

```

### Before
![before](https://github.com/uga-rosa/ddu-filter-converter_devicon/assets/100141359/a080e67b-307f-45b6-8270-b9962ce6f733)

### After
![after](https://github.com/uga-rosa/ddu-filter-converter_devicon/assets/100141359/39473a48-81e2-4bf0-b544-024b9ca41825)
